### PR TITLE
Issue #7: Prompt user to add item if list is empty 

### DIFF
--- a/src/Components/FirestoreList.jsx
+++ b/src/Components/FirestoreList.jsx
@@ -16,6 +16,7 @@ export default function FirestoreList({ token }) {
         itemList.push(value);
       }
     });
+    console.log(itemList);
     return itemList;
   };
 

--- a/src/Components/FirestoreList.jsx
+++ b/src/Components/FirestoreList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FirestoreDocument } from 'react-firestore';
-import List from './List';
+import List from './List/List';
 
 /**
  * Retrieves token from local storage and accesses the saved items list from Firestore

--- a/src/Components/FirestoreList.jsx
+++ b/src/Components/FirestoreList.jsx
@@ -16,7 +16,6 @@ export default function FirestoreList({ token }) {
         itemList.push(value);
       }
     });
-    console.log(itemList);
     return itemList;
   };
 

--- a/src/Components/List.jsx
+++ b/src/Components/List.jsx
@@ -1,12 +1,19 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 
 export default function List({ items }) {
+  let history = useHistory();
+
+  const redirectPath = () => {
+    history.push('/add-item');
+  };
+
   return (
     <div className="List">
       {items.length === 0 ? (
         <React.Fragment>
           <h3>Your shopping list is empty.</h3>
-          <button>Add New Item</button>
+          <button onClick={redirectPath}>Add New Item</button>
         </React.Fragment>
       ) : (
         <React.Fragment>

--- a/src/Components/List.jsx
+++ b/src/Components/List.jsx
@@ -3,12 +3,27 @@ import React from 'react';
 export default function List({ items }) {
   return (
     <div className="List">
-      <h3>Item List:</h3>
-      <ul>
-        {items.map((item) => (
-          <li>{item.name}</li>
-        ))}
-      </ul>
+      {items.length === 0 ? (
+        <React.Fragment>
+          <h3>Your shopping list is empty.</h3>
+          <button>Add New Item</button>
+        </React.Fragment>
+      ) : (
+        <React.Fragment>
+          <h3>Item List:</h3>
+
+          <ul>
+            {items.map((item) => (
+              <li key={item.name}>{item.name}</li>
+            ))}
+          </ul>
+        </React.Fragment>
+      )}
     </div>
   );
 }
+
+// To do:
+// - If the itemList array is empty, show button to add first item
+// Use react-router to re-route to add item page
+// - If the itemList array is not empty, show the list

--- a/src/Components/List/List.css
+++ b/src/Components/List/List.css
@@ -1,12 +1,15 @@
-.emptyList {
+.listContainer {
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+
+.listContainer.emptyList {
   height: 60vh;
 }
 
-.emptyList p {
+.listContainer h3 {
   font-size: 1.3rem;
 }
 

--- a/src/Components/List/List.css
+++ b/src/Components/List/List.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  height: 60vh;
 }
 
 .emptyList p {

--- a/src/Components/List/List.css
+++ b/src/Components/List/List.css
@@ -1,0 +1,33 @@
+.emptyList {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.emptyList p {
+  font-size: 1.3rem;
+}
+
+.List {
+  padding: 0.5rem 2rem;
+}
+
+.List button {
+  color: black;
+  background-color: lightskyblue;
+  text-decoration: none;
+  padding: 10px 20px;
+  text-align: center;
+  border: 1px solid black;
+  border-radius: 5px;
+  transition: transform 0.3s ease-in-out;
+  font-size: 1rem;
+  font-weight: bold;
+  width: 175px;
+  margin: 1rem 0;
+}
+
+.List button:hover {
+  background-color: lightsteelblue;
+}

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -12,12 +12,14 @@ export default function List({ items }) {
   return (
     <div className="List">
       {items.length === 0 ? (
-        <section className="emptyList">
-          <p>Your shopping list is empty. Add a new item to start your list.</p>
+        <section className="listContainer emptyList">
+          <h3>
+            Your shopping list is empty. Add a new item to start your list.
+          </h3>
           <button onClick={redirectPath}>Add New Item</button>
         </section>
       ) : (
-        <React.Fragment>
+        <section className="listContainer">
           <h3>Item List:</h3>
 
           <ul>
@@ -25,13 +27,8 @@ export default function List({ items }) {
               <li key={item.name}>{item.name}</li>
             ))}
           </ul>
-        </React.Fragment>
+        </section>
       )}
     </div>
   );
 }
-
-// To do:
-// - If the itemList array is empty, show button to add first item
-// Use react-router to re-route to add item page
-// - If the itemList array is not empty, show the list

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import '../List/List.css';
+import './List.css';
 
 export default function List({ items }) {
   let history = useHistory();

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
+import '../List/List.css';
 
 export default function List({ items }) {
   let history = useHistory();
@@ -12,7 +13,7 @@ export default function List({ items }) {
     <div className="List">
       {items.length === 0 ? (
         <React.Fragment>
-          <h3>Your shopping list is empty.</h3>
+          <p>Your shopping list is empty. Add a new item to start your list.</p>
           <button onClick={redirectPath}>Add New Item</button>
         </React.Fragment>
       ) : (

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -12,10 +12,10 @@ export default function List({ items }) {
   return (
     <div className="List">
       {items.length === 0 ? (
-        <React.Fragment>
+        <section className="emptyList">
           <p>Your shopping list is empty. Add a new item to start your list.</p>
           <button onClick={redirectPath}>Add New Item</button>
-        </React.Fragment>
+        </section>
       ) : (
         <React.Fragment>
           <h3>Item List:</h3>

--- a/src/Components/NavBar/NavBar.css
+++ b/src/Components/NavBar/NavBar.css
@@ -16,6 +16,7 @@
   width: 100px;
   text-align: center;
   border: 1px solid black;
+  border-radius: 5px;
   transition: transform 0.3s ease-in-out;
 }
 


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._ 

## Description

- Created button and prompt for user to add a new item if list is empty
- When user clicks on add new item button, they are rerouted to add an item page 
- When the user adds an item or if a list already exists, user will see the list view 

## Related Issue

Closes #7 

## Acceptance Criteria

- The list view, when there are no items to display, should show a prompt (e.g., a button) for the user to add their first item

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![Screen Shot 2020-10-26 at 12 43 59 PM](https://user-images.githubusercontent.com/61370161/97208383-12e6b500-1789-11eb-8998-3eb2c9fc0752.png)


### After

![tcl-12-issue-7](https://user-images.githubusercontent.com/61370161/97209399-4b3ac300-178a-11eb-8094-f99070fc23d2.gif)


## Testing Steps / QA Criteria

- Switch to our branch (`git checkout al-eb-add-first-item`), then run `git pull origin al-eb-add-first-item`. Start server.
- Create a new token or choose a token from the Firestore database that has no list items 
- A message should appear on lists page that informs user that the list is empty and prompts the user to add an item 
- Click the "Add New Item" button to be rerouted to the Add an Item page

