### PR TITLE
Issue #8: Mark an Item as Purchased

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12398,10 +12398,9 @@
       }
     },
     "moment": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.28.0.tgz",
-      "integrity": "sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw==",
-      "dev": true
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5794,6 +5794,11 @@
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
     },
+    "dayjs": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.4.tgz",
+      "integrity": "sha512-ABSF3alrldf7nM9sQ2U+Ln67NRwmzlLOqG7kK03kck0mw3wlSSEKv/XhKGGxUjQcS57QeiCyNdrFgtj9nWlrng=="
+    },
     "debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -12400,7 +12405,8 @@
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "firebase": "^7.22.1",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
+    "moment": "^2.29.1",
     "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "dependencies": {
     "@testing-library/react": "^11.0.4",
+    "dayjs": "^1.9.4",
     "firebase": "^7.22.1",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
-    "moment": "^2.29.1",
     "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/Components/FirestoreList.jsx
+++ b/src/Components/FirestoreList.jsx
@@ -26,7 +26,7 @@ export default function FirestoreList({ token }) {
         return isLoading ? (
           <div>Loading</div>
         ) : (
-          <List items={dataToArray(data)} />
+          <List items={dataToArray(data)} token={token} />
         );
       }}
     />

--- a/src/Components/FirestoreList.jsx
+++ b/src/Components/FirestoreList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FirestoreDocument } from 'react-firestore';
-import List from './List';
+import List from './List/List';
 
 /**
  * Retrieves token from local storage and accesses the saved items list from Firestore

--- a/src/Components/List.jsx
+++ b/src/Components/List.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { db } from '../lib/firebase';
 import { formatString } from '../lib/helpers.js';
+import moment from 'moment';
 
 export default function List({ items, token }) {
   // function check(){
@@ -32,6 +33,18 @@ export default function List({ items, token }) {
     // });
   };
 
+  const checked = (item) => {
+    const time = moment();
+    const purchasedAt = moment(item.lastPurchased.toDate());
+    const diff = time.diff(purchasedAt, 'h');
+
+    if (item.lastPurchased === null || diff >= 24) {
+      return false;
+    } else {
+      return true;
+    }
+  };
+
   return (
     <div className="List">
       <h3>Item List:</h3>
@@ -40,8 +53,10 @@ export default function List({ items, token }) {
           <div>
             <input
               type="checkbox"
-              class="checked"
-              onClick={() => purchaseItem(item)}
+              className="checked"
+              onChange={() => purchaseItem(item)}
+              checked={checked(item)}
+              disabled={checked(item)}
             />
             <label>{item.name}</label>
           </div>

--- a/src/Components/List.jsx
+++ b/src/Components/List.jsx
@@ -1,12 +1,50 @@
 import React from 'react';
+import { db } from '../lib/firebase';
+import { formatString } from '../lib/helpers.js';
 
-export default function List({ items }) {
+export default function List({ items, token }) {
+  // function check(){
+  //   if(document.querySelectorAll("#checked").is(":checked")){
+  //     document.querySelectorAll
+  //   }
+  // }
+
+  const purchaseItem = (item) => {
+    const normalizedName = formatString(item.name);
+    db.collection('lists')
+      .doc(token)
+      .update({
+        [normalizedName]: {
+          name: item.name,
+          frequency: item.frequency,
+          lastPurchased: new Date(),
+        },
+      });
+    // .then(() => {
+    //   alert('Item has been submitted!');
+    //   reset();
+    // })
+    // .catch((e) => {
+    //   console.log('Error updating Firestore: ', e);
+    //   alert(
+    //     `It isn't you, it's us. The item cannot be submitted at this time. Try again later while we look into it.`,
+    //   );
+    // });
+  };
+
   return (
     <div className="List">
       <h3>Item List:</h3>
       <ul>
         {items.map((item) => (
-          <li>{item.name}</li>
+          <div>
+            <input
+              type="checkbox"
+              class="checked"
+              onClick={() => purchaseItem(item)}
+            />
+            <label>{item.name}</label>
+          </div>
         ))}
       </ul>
     </div>

--- a/src/Components/List/List.css
+++ b/src/Components/List/List.css
@@ -1,11 +1,11 @@
 .List {
   padding: 0.5rem 2rem;
 }
-input[type='checkbox'] {
+.List input[type='checkbox'] {
   margin: 20px 20px 20px 0;
   transform: scale(2);
 }
-input:checked + label {
+.List input:checked + label {
   text-decoration: line-through;
   color: gray;
 }

--- a/src/Components/List/List.css
+++ b/src/Components/List/List.css
@@ -1,0 +1,11 @@
+.List {
+  padding: 0.5rem 2rem;
+}
+input[type='checkbox'] {
+  margin: 20px 20px 20px 0;
+  transform: scale(2);
+}
+input:checked + label {
+  text-decoration: line-through;
+  color: gray;
+}

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { db } from '../lib/firebase';
-import { formatString } from '../lib/helpers.js';
+import { db } from '../../lib/firebase.js';
+import { formatString } from '../../lib/helpers.js';
 import moment from 'moment';
+import './List.css';
 
 export default function List({ items, token }) {
   // function check(){
@@ -36,9 +37,9 @@ export default function List({ items, token }) {
   const checked = (item) => {
     const time = moment();
     const purchasedAt = moment(item.lastPurchased.toDate());
-    const diff = time.diff(purchasedAt, 'h');
+    const diff = time.diff(purchasedAt, 's');
 
-    if (item.lastPurchased === null || diff >= 24) {
+    if (item.lastPurchased === null || diff >= 5) {
       return false;
     } else {
       return true;

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -38,7 +38,7 @@ export default function List({ items, token }) {
           let checked = isChecked(item);
 
           return (
-            <div>
+            <div key={item.name}>
               <input
                 type="checkbox"
                 className="checked"

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -24,9 +24,9 @@ export default function List({ items, token }) {
     } else {
       const time = dayjs();
       const purchasedAt = dayjs(item.lastPurchased.toDate());
-      const diff = time.diff(purchasedAt, 'h');
+      const differenceInHours = time.diff(purchasedAt, 'h');
 
-      return diff <= 24;
+      return differenceInHours <= 24;
     }
   };
 

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -26,7 +26,7 @@ export default function List({ items, token }) {
       const purchasedAt = dayjs(item.lastPurchased.toDate());
       const differenceInHours = time.diff(purchasedAt, 'h');
 
-      return differenceInHours <= 24;
+      return differenceInHours < 24;
     }
   };
 

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -5,12 +5,6 @@ import moment from 'moment';
 import './List.css';
 
 export default function List({ items, token }) {
-  // function check(){
-  //   if(document.querySelectorAll("#checked").is(":checked")){
-  //     document.querySelectorAll
-  //   }
-  // }
-
   const purchaseItem = (item) => {
     const normalizedName = formatString(item.name);
     db.collection('lists')
@@ -22,27 +16,17 @@ export default function List({ items, token }) {
           lastPurchased: new Date(),
         },
       });
-    // .then(() => {
-    //   alert('Item has been submitted!');
-    //   reset();
-    // })
-    // .catch((e) => {
-    //   console.log('Error updating Firestore: ', e);
-    //   alert(
-    //     `It isn't you, it's us. The item cannot be submitted at this time. Try again later while we look into it.`,
-    //   );
-    // });
   };
 
-  const checked = (item) => {
-    const time = moment();
-    const purchasedAt = moment(item.lastPurchased.toDate());
-    const diff = time.diff(purchasedAt, 's');
-
-    if (item.lastPurchased === null || diff >= 5) {
+  const isChecked = (item) => {
+    if (item.lastPurchased === null) {
       return false;
     } else {
-      return true;
+      const time = moment();
+      const purchasedAt = moment(item.lastPurchased.toDate());
+      const diff = time.diff(purchasedAt, 'h'); //s to h once fixed
+
+      return diff <= 24;
     }
   };
 
@@ -50,18 +34,23 @@ export default function List({ items, token }) {
     <div className="List">
       <h3>Item List:</h3>
       <ul>
-        {items.map((item) => (
-          <div>
-            <input
-              type="checkbox"
-              className="checked"
-              onChange={() => purchaseItem(item)}
-              checked={checked(item)}
-              disabled={checked(item)}
-            />
-            <label>{item.name}</label>
-          </div>
-        ))}
+        {items.map((item) => {
+          let checked = isChecked(item);
+
+          return (
+            <div>
+              <input
+                type="checkbox"
+                className="checked"
+                id={item.name}
+                onChange={() => purchaseItem(item)}
+                checked={checked}
+                disabled={checked}
+              />
+              <label htmlFor={item.name}>{item.name}</label>
+            </div>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { db } from '../../lib/firebase.js';
 import { formatString } from '../../lib/helpers.js';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import './List.css';
 
 export default function List({ items, token }) {
@@ -22,9 +22,9 @@ export default function List({ items, token }) {
     if (item.lastPurchased === null) {
       return false;
     } else {
-      const time = moment();
-      const purchasedAt = moment(item.lastPurchased.toDate());
-      const diff = time.diff(purchasedAt, 'h'); //s to h once fixed
+      const time = dayjs();
+      const purchasedAt = dayjs(item.lastPurchased.toDate());
+      const diff = time.diff(purchasedAt, 'h');
 
       return diff <= 24;
     }


### PR DESCRIPTION
## Description
- Added checkboxes next to each item
- Clicking the checkbox will update the item's lastPurchased date on the Firestore
- The checkbox will be disabled for up to 24 hours since the lastPurchased date
- Added the DayJS package

## Related Issue
Closes #8 

## Acceptance Criteria
- [x] User is able to tap a checkbox or similar UI element to mark an item in the list as purchased
- [x] Item should be shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring      |
|    | :100: Add tests            |
|  ✓ | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
![Checkbox-before](https://user-images.githubusercontent.com/39573970/97371127-d5a82300-186d-11eb-83f6-9f6273b7482f.png)

### After
![Checkbox-after](https://user-images.githubusercontent.com/39573970/97371210-f5d7e200-186d-11eb-8462-d1b30f7a32b0.png)

## Testing Steps / QA Criteria
- Pull latest from `tc-gj-mark-as-purchased`
- Install latest dependencies `npm install`
- Run server `npm start`
- Open up Firestore
- Create a new list of items or open an existing list
- Click one of the check boxes, it should then be disabled and the lastPurchased date of the item is set to the current time in the Firestore
- Change the lastPurchased date of the item in the Firestore to an earlier date (24 hours or more) to see the checkbox enabled again


