### PR TITLE
Issues #12: Sort shopping list by how soon user will need to buy item again

### DIFF
--- a/PROJECT-BRIEF.md
+++ b/PROJECT-BRIEF.md
@@ -14,7 +14,7 @@ This project is based on [iNeedToBuy.xyz](https://app.ineedtobuy.xyz/), a mobile
 - Repo: [github.com/the-collab-lab/tcl-12-smart-shopping-list](https://github.com/the-collab-lab/tcl-12-smart-shopping-list)
 - Clone URL: `git@github.com:the-collab-lab/tcl-12-smart-shopping-list.git`
 - Issue list: [github.com/the-collab-lab/tcl-12-smart-shopping-list/projects/1](https://github.com/the-collab-lab/tcl-12-smart-shopping-list/projects/1)
-- Database: [console.firebase.google.com/u/0/project/tcl-12-smart-shopping-list/database](https://console.firebase.google.com/u/0/project/tcl-12-smart-shopping-list/database)
+- Database: [console.firebase.google.com/u/0/project/tcl-12-smart-shopping-list/firestore](https://console.firebase.google.com/u/0/project/tcl-12-smart-shopping-list/firestore)
 
 ### Project cadence & duration
 

--- a/src/Components/List/List.css
+++ b/src/Components/List/List.css
@@ -7,7 +7,7 @@
 }
 .List input:checked + label {
   text-decoration: line-through;
-  color: gray;
+  color: rgb(44, 44, 44);
 }
 
 .emptyList {
@@ -87,32 +87,30 @@
 }
 
 /* Issue #12 css */
+
+.badge {
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  margin-left: 0.3rem;
+  font-size: 12px;
+}
+
 .inactive {
-  background-color: rgb(165, 164, 164);
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
+  background-color: rgb(202, 202, 202);
 }
 
 .soon {
   background-color: rgb(155, 255, 155);
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
 }
 
 .kindOfSoon {
   background-color: rgb(250, 198, 101);
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
 }
 
 .notSoon {
   background-color: rgb(255, 151, 151);
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
 }
 
 .notBought {
   background-color: rgb(250, 195, 255);
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
 }

--- a/src/Components/List/List.css
+++ b/src/Components/List/List.css
@@ -85,3 +85,28 @@
 .resetButton:hover {
   cursor: pointer;
 }
+
+/* Issue #12 css */
+.inactive {
+  color: red;
+}
+
+.soon {
+  background-color: green;
+  padding: 0.5rem 1rem;
+}
+
+.kindOfSoon {
+  background-color: orange;
+  padding: 0.5rem 1rem;
+}
+
+.notSoon {
+  background-color: red;
+  padding: 0.5rem 1rem;
+}
+
+.notBought {
+  background-color: gold;
+  padding: 0.5rem 1rem;
+}

--- a/src/Components/List/List.css
+++ b/src/Components/List/List.css
@@ -88,25 +88,31 @@
 
 /* Issue #12 css */
 .inactive {
-  color: red;
+  background-color: rgb(165, 164, 164);
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
 }
 
 .soon {
-  background-color: green;
+  background-color: rgb(155, 255, 155);
   padding: 0.5rem 1rem;
+  border-radius: 6px;
 }
 
 .kindOfSoon {
-  background-color: orange;
+  background-color: rgb(250, 198, 101);
   padding: 0.5rem 1rem;
+  border-radius: 6px;
 }
 
 .notSoon {
-  background-color: red;
+  background-color: rgb(255, 151, 151);
   padding: 0.5rem 1rem;
+  border-radius: 6px;
 }
 
 .notBought {
-  background-color: gold;
+  background-color: rgb(250, 195, 255);
   padding: 0.5rem 1rem;
+  border-radius: 6px;
 }

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -4,11 +4,11 @@ WHAT WORKS
 - Target inactive items. Gotta figure out what to do with them
 - Created countdown of days to use for color code
 - Color code items (reference issue to maybe adjust time lengths)
+- Make color coded screen reader friendly
 
 TO DO:
 - Fix alphabetically
 - Figure out what to do with inactives (do they need to coexist with color coded? If so, how?)
-- Make color coded screen reader friendly 
 
 BONUSES (stuff we'll probably get told to do during PRs):
 - Turn if statements to Switch statements
@@ -72,12 +72,8 @@ const purchaseItem = (item, token) => {
     });
 };
 
-//Color code based on days until next purchase
+//Color code based on days until next purchase with corresponding aria label
 const colorCode = (item) => {
-  const soonLabel = 'soon';
-  const kindOfSoonLabel = 'kindOfSoon';
-  const notSoonLabel = 'notSoon';
-  const notBought = 'notBought';
   const daysSincePurchased = dayjs().diff(
     getLastPurchaseDate(item, item.lastPurchased),
     'day',
@@ -85,13 +81,13 @@ const colorCode = (item) => {
   const estimatedCountdown = item.calculatedEstimate - daysSincePurchased;
 
   if (estimatedCountdown <= 7) {
-    return soonLabel;
+    return ['soon', 'Within 7 days'];
   } else if (estimatedCountdown <= 14) {
-    return kindOfSoonLabel;
+    return ['kindOfSoon', 'Between 7 and 14 days'];
   } else if (14 < estimatedCountdown) {
-    return notSoonLabel;
+    return ['notSoon', 'More than 14 days'];
   } else if (isNaN(estimatedCountdown)) {
-    return notBought;
+    return ['notBought', 'Never Bought Yet'];
   } else {
     return null;
   }
@@ -107,7 +103,7 @@ const isInactive = (item) => {
   );
 
   const inactiveLabel = (
-    <label htmlFor={item.name} className="inactive">
+    <label htmlFor={item.name} className="inactive" aria-label="Inactive">
       {item.name}
     </label>
   );
@@ -225,7 +221,11 @@ export default function List({ items, token }) {
                     />
                     {isInactive(item)}{' '}
                     {/*temporarily overwriting label until we figure out what to do with inactives */}
-                    <label htmlFor={item.name} className={colorCode(item)}>
+                    <label
+                      htmlFor={item.name}
+                      className={colorCode(item)[0]}
+                      aria-label={colorCode(item)[1]}
+                    >
                       {item.name}
                     </label>
                   </div>

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -5,19 +5,16 @@ WHAT WORKS
 - Created countdown of days to use for color code
 - Color code items (reference issue to maybe adjust time lengths)
 - Make color coded screen reader friendly
+- Order alphabetically
 
 TO DO:
 ****** HELP ********
 ***** If you wanna give this a go, have at it! We're completely stuck at this point ******
 
-1. Fix alphabetically
-  - The items are successfully sorted by calculatedEstimate, but the bottom 3 pink ones are "undefined" because they've never been bought yet. These will not order alphabetically as they should in all the variations we tried.
-2. Move inactive to bottom
+1. Move inactive to bottom
   - calculatedEstimate is taking priority over Inactive, so it's staying in it's same calculatedEstimate spot.
   - When we try adding more conditionals related to "inactive" or "0" to .sort, it just breaks the working sort.
   - When console.logging pretty much anything we're having trouble with (For example "a.name" within the .sort), there's lots of repeats of the same item but we have no clue what's happening to make that happen
-
---- We believe both issues may have something to do with Firestore being objects and not arrays, but maybe you can prove us wrong!
 */
 
 import React from 'react';
@@ -107,18 +104,16 @@ const colorCode = (item) => {
 
 // Sort items by soonest to latest estimated repurchase
 const sortItems = (a, b) => {
-  if (
+  if (a.calculatedEstimate === b.calculatedEstimate) {
+    return a.name.localeCompare(b.name, 'en', { sensitivity: 'base' });
+  } else if (
     a.calculatedEstimate < b.calculatedEstimate ||
     b.calculatedEstimate === undefined
   ) {
     return -1;
-  } else if (a.calculatedEstimate > b.calculatedEstimate) {
+  } else {
     return 1;
-  } else if (a.calculatedEstimate === b.calculatedEstimate) {
-    //This doesn't order names as it should. Tried localeCompare, > <, -, nested if
-    return a.name.localeCompare(b.name, 'en', { sensitivity: 'base' });
   }
-  console.log(a.name);
 };
 
 export default function List({ items, token }) {

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -6,6 +6,12 @@ import calculateEstimate from '../../lib/estimates';
 import dayjs from 'dayjs';
 import './List.css';
 
+// var relativeTime = require('dayjs/plugin/relativeTime');
+// dayjs.extend(relativeTime);
+
+var isSameOrAfter = require('dayjs/plugin/isSameOrAfter');
+dayjs.extend(isSameOrAfter);
+
 const getNumberOfPurchases = (item) => {
   if (item.numberOfPurchases === undefined) {
     return 1;
@@ -82,6 +88,21 @@ export default function List({ items, token }) {
         item.name.toLowerCase().includes(searchItem.toLocaleLowerCase()),
       );
 
+  const setElapsedTime = (item) => {
+    const elapsedTime = dayjs().isSameOrAfter(
+      dayjs(getLastPurchaseDate(item, item.lastPurchased)).add(
+        item.calculatedEstimate * 2,
+        'day',
+      ),
+    );
+    if (elapsedTime === true) {
+      console.log(elapsedTime);
+    } else {
+      return null;
+    }
+  };
+  // console.log(setElapsedTime());
+
   return (
     <div className="List">
       {items.length === 0 ? (
@@ -117,6 +138,7 @@ export default function List({ items, token }) {
               </button>
             )}
           </div>
+
           <div role="region" id="itemsList" aria-live="polite">
             {/*
               Successfully sorts by calculatedEstimate time. Alphabetical doesn't work.
@@ -135,18 +157,19 @@ export default function List({ items, token }) {
                   b.calculatedEstimate === undefined
                 ) {
                   return -1;
-                }
-                if (a.calculatedEstimate > b.calculatedEstimate) {
+                } else if (a.calculatedEstimate > b.calculatedEstimate) {
                   return 1;
-                }
-                if (a.calculatedEstimate === b.calculatedEstimate) {
+                } else if (a.calculatedEstimate === b.calculatedEstimate) {
+                  //   a.lastPurchased === b.lastPurchased &&
+                  //   a.item.lastPurchased === undefined
+                  // ) {
                   //This doesn't order names as it should. Tried name, item.name, making item.name a variable
-                  if (a.name < b.name) {
+                  // if (a.lastPurchased == null) {
+                  if (a.name.localeCompare(b.name) && a.name < b.name) {
                     return -1;
-                  } else {
-                    return 1;
                   }
                 }
+                // console.log();
               })
               .map((item) => {
                 let checked = isChecked(item);
@@ -162,9 +185,16 @@ export default function List({ items, token }) {
                       disabled={checked}
                     />
                     <label htmlFor={item.name}>{item.name}</label>
+
                     {
                       console.log(
+                        // (item.calculatedEstimate * 2) >= item.currentDate.diff(item.lastPurchaseDate),
+                        // dayjs(
+                        //   getLastPurchaseDate(item, item.lastPurchased),
+                        // ).from(getLastPurchaseDate(item, item.currentDate)),
                         item.calculatedEstimate,
+
+                        // const timeFrames = dayjs(item.calculatedEstimate * 2) - dayjs(item.lastPurchased);
                       ) /*Using to see how items are ordered when sorted */
                     }
                   </div>

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -5,15 +5,16 @@ WHAT WORKS
 - Created countdown of days to use for color code
 - Color code items (reference issue to maybe adjust time lengths)
 - Make color coded screen reader friendly
+- Turn if statements to Switch statements (Bonus)
 
 TO DO:
 - Fix alphabetically
 - Figure out what to do with inactives (do they need to coexist with color coded? If so, how?)
 
 BONUSES (stuff we'll probably get told to do during PRs):
-- Turn if statements to Switch statements
 - Refactor
   - Maybe make sorting and color coding their own file and import them
+  - Any functions we can move out?
 */
 
 import React from 'react';
@@ -80,16 +81,17 @@ const colorCode = (item) => {
   );
   const estimatedCountdown = item.calculatedEstimate - daysSincePurchased;
 
-  if (estimatedCountdown <= 7) {
-    return ['soon', 'Within 7 days'];
-  } else if (estimatedCountdown <= 14) {
-    return ['kindOfSoon', 'Between 7 and 14 days'];
-  } else if (14 < estimatedCountdown) {
-    return ['notSoon', 'More than 14 days'];
-  } else if (isNaN(estimatedCountdown)) {
-    return ['notBought', 'Never Bought Yet'];
-  } else {
-    return null;
+  switch (true) {
+    case estimatedCountdown <= 7:
+      return ['soon', 'Within 7 days'];
+    case estimatedCountdown <= 14:
+      return ['kindOfSoon', 'Between 7 and 14 days'];
+    case 14 < estimatedCountdown:
+      return ['notSoon', 'More than 14 days'];
+    case isNaN(estimatedCountdown):
+      return ['notBought', 'Never Bought Yet'];
+    default:
+      return null;
   }
 };
 
@@ -191,19 +193,18 @@ export default function List({ items, token }) {
             {/* Sort items by soonest to latest estimated repurchase  */}
             {results
               .sort((a, b) => {
-                // to remove yellow =>, change to Switch statement since there's no else
-                if (
-                  a.calculatedEstimate < b.calculatedEstimate ||
-                  b.calculatedEstimate === undefined
-                ) {
-                  return -1;
-                } else if (a.calculatedEstimate > b.calculatedEstimate) {
-                  return 1;
-                } else if (a.calculatedEstimate === b.calculatedEstimate) {
-                  //This doesn't order names as it should. Tried name, item.name, making item.name a variable
-                  if (a.name.localeCompare(b.name) && a.name < b.name) {
+                switch (true) {
+                  case a.calculatedEstimate < b.calculatedEstimate ||
+                    b.calculatedEstimate === undefined:
                     return -1;
-                  }
+                  case a.calculatedEstimate > b.calculatedEstimate:
+                    return 1;
+                  case a.calculatedEstimate === b.calculatedEstimate:
+                    if (a.name.localeCompare(b.name) && a.name < b.name) {
+                      return -1;
+                    } else return null;
+                  default:
+                    return null;
                 }
               })
               .map((item) => {

--- a/src/Components/List/List.jsx
+++ b/src/Components/List/List.jsx
@@ -25,7 +25,7 @@ import calculateEstimate from '../../lib/estimates';
 import dayjs from 'dayjs';
 import './List.css';
 
-var isSameOrAfter = require('dayjs/plugin/isSameOrAfter');
+const isSameOrAfter = require('dayjs/plugin/isSameOrAfter');
 dayjs.extend(isSameOrAfter);
 
 // Update how many times an item has been bought once checked
@@ -88,24 +88,43 @@ const colorCode = (item) => {
   );
 
   if (elapsedTime === true) {
-    return ['inactive', 'Inactive'];
+    return ['inactive', ' Inactive'];
   } else if (estimatedCountdown <= 7) {
-    return ['soon', 'Within 7 days'];
+    return ['soon', ' Within 7 days'];
   } else if (estimatedCountdown <= 14) {
-    return ['kindOfSoon', 'Between 7 and 14 days'];
+    return ['kindOfSoon', ' Between 7 and 14 days'];
   } else if (14 < estimatedCountdown) {
-    return ['notSoon', 'More than 14 days'];
+    return ['notSoon', ' More than 14 days'];
   } else if (isNaN(estimatedCountdown)) {
-    return ['notBought', 'Never Bought Yet'];
+    return ['notBought', ' Never Bought Yet'];
   } else {
     return null;
   }
 };
 
+// Attempted to add className label to each item's frequency
+
+// if (estimatedCountdown <= 7) {
+//   item.className = 'soon';
+// } else if (estimatedCountdown <= 14) {
+//   item.className = 'kindOfSoon';
+// } else if (14 < estimatedCountdown) {
+//   item.className = 'notSoon';
+// } else if (isNaN(estimatedCountdown)) {
+//   item.className = 'notBought';
+// }
+// if (elapsedTime === true) {
+//   item.className = 'inactive';
+// } else {
+//   return item;
+// }
+
 // Sort items by soonest to latest estimated repurchase
 const sortItems = (a, b) => {
-  if (a.calculatedEstimate === b.calculatedEstimate) {
-    return a.name.localeCompare(b.name, 'en', { sensitivity: 'base' });
+  if (b.name === undefined) {
+    return -1;
+  } else if (a.calculatedEstimate === b.calculatedEstimate) {
+    return a.name.localeCompare(b.name, { sensitivity: 'base' });
   } else if (
     a.calculatedEstimate < b.calculatedEstimate ||
     b.calculatedEstimate === undefined
@@ -115,6 +134,33 @@ const sortItems = (a, b) => {
     return 1;
   }
 };
+
+// Attempted to compare className in order to reorder item order
+
+// const sortItems = (a, b) => {
+//     if (a.className === 'inactive' && b.className === 'inactive') {
+//       return a.title.localeCompare(b.title);
+//     }
+//     if (a.className === 'inactive' && b.className !== 'inactive') {
+//       return 1;
+//     }
+//     if (a.className !== 'inactive' && b.className === 'inactive') {
+//       return -1;
+//     }
+//     if (a.className !== 'inactive' && b.className !== 'inactive') {
+//       if (b.calculatedEstimate === undefined) {
+//         return -1;
+//       }
+//     }
+//     if (a.calculateEstimate > b.calculateEstimate) {
+//       return 1;
+//     }
+//     if (a.calculateEstimate < b.calculateEstimate) {
+//       return -1;
+//     }
+//     return a.name.localeCompare(b.name, { sensitivity: 'base' });
+//   };
+// };
 
 export default function List({ items, token }) {
   let history = useHistory();
@@ -189,29 +235,34 @@ export default function List({ items, token }) {
           </div>
 
           <div role="region" id="itemsList" aria-live="polite">
-            {results.sort(sortItems).map((item) => {
-              let checked = isChecked(item);
+            {results
+              // .map(addClassName)
+              .sort(sortItems)
+              .map((item) => {
+                let checked = isChecked(item);
 
-              return (
-                <div key={item.name}>
-                  <input
-                    type="checkbox"
-                    className="checked"
-                    id={item.name}
-                    onChange={() => purchaseItem(item, token)}
-                    checked={checked}
-                    disabled={checked}
-                  />
-                  <label
-                    htmlFor={item.name}
-                    className={colorCode(item)[0]}
-                    aria-label={colorCode(item)[1]}
-                  >
-                    {item.name}
-                  </label>
-                </div>
-              );
-            })}
+                return (
+                  <div key={item.name}>
+                    <input
+                      type="checkbox"
+                      className="checked"
+                      id={item.name}
+                      onChange={() => purchaseItem(item, token)}
+                      checked={checked}
+                      disabled={checked}
+                    />
+                    <label htmlFor={item.name}>
+                      {item.name}
+                      <span
+                        className={`${colorCode(item)[0]} badge`}
+                        aria-hidden="true"
+                      >
+                        {colorCode(item)[1]}
+                      </span>
+                    </label>
+                  </div>
+                );
+              })}
           </div>
         </section>
       )}


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._ 

## Description

- Ordered list items by calculated estimate of next time item would need to be purchased 
- Distinguished items that need to be purchased soon, kind of soon, not soon, inactive, and not yet purchased at the top by different colors

HAVE NOT COMPLETED: 
- ~~We struggled with the issue this week, mostly because our items are listed as objects vs an array in the Firestore database. We could not figure out how to order the items that have not been purchased alphabetically.~~
    - Terry recommended we move the "===" comparison to the top because it never got a chance to be read after the other conditionals
- ~~We also were trying to figure out how to move items that switch to inactive to the bottom of our item list. After researching for a few hours, we decided it would be best to ask the team and mentors if they could think of the best way to do this.~~
    - Terry again suggested code on how go about sorting Inactive before calculatedEstimate by repurposing the elapsedTime variable

## Related Issue

Issue #12 

## Acceptance Criteria

- [x] Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive

- [x] Items should be sorted by the estimated number of days until next purchase
- [x] Items with the same number of estimated days until next purchase should be sorted alphabetically
- [x] Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<img width="862" alt="Screen Shot 2020-11-12 at 2 03 05 AM" src="https://user-images.githubusercontent.com/24923742/98912118-49ac1300-248b-11eb-8c9b-33d1a44e1028.png">


### After

<img width="865" alt="Screen Shot 2020-11-12 at 2 01 42 AM" src="https://user-images.githubusercontent.com/24923742/98912267-77915780-248b-11eb-81f9-e8a1b76421a5.png">


### After: Part 2

![After-2](https://user-images.githubusercontent.com/24923742/99114133-f5ea1880-25b5-11eb-9c8a-10806130dff1.png)


## Testing Steps / QA Criteria

- Switch to our branch (`git checkout gj-eb-sort-items`), then run `git pull origin gj-eb-sort-items`. Start server. 
- Input the token `mind shoo cuff`
- Open Firestore Console and find the corresponding token
- Items should appear in the app list in order of estimated days until next purchase (soonest, kind of soon, not soon, not purchased)
- Change the oldPurchased date in Firestore for an active item to a date that is more than calculatedEstimate x2 days before the lastPurchased date (if you need to, change calculatedEstimate to a lower number) to see it become inactive on the app
